### PR TITLE
Bulk hover

### DIFF
--- a/src/components/prompt/AnchorHighlights.tsx
+++ b/src/components/prompt/AnchorHighlights.tsx
@@ -11,9 +11,9 @@ export interface AnchorHighlightProps {
   prompts: PromptsState;
   promptLocations: { [id: string]: PromptLocation };
   visiblePromptIDs: Set<string>;
-  hoverPrompt: string | undefined;
-  editPrompt: string | undefined;
-  setHoverPrompt: (id: string | undefined) => any;
+  hoverPrompts: PromptId[] | undefined;
+  editPrompt: PromptId | undefined;
+  setHoverPrompt: (id: PromptId | undefined) => any;
 }
 
 function areRangesSame(rangeA: Range, rangeB: Range): boolean {
@@ -23,7 +23,7 @@ function areRangesSame(rangeA: Range, rangeB: Range): boolean {
   );
 }
 
-function classNameForPromptID(id: string): string {
+function classNameForPromptID(id: PromptId): string {
   return `orbitanchor-${id.replace(/ /g, "-")}`;
 }
 
@@ -31,7 +31,7 @@ export function AnchorHighlight({
   prompts,
   promptLocations,
   visiblePromptIDs,
-  hoverPrompt,
+  hoverPrompts,
   editPrompt,
   setHoverPrompt,
 }: AnchorHighlightProps) {
@@ -75,28 +75,30 @@ export function AnchorHighlight({
     });
 
     // Apply hover if eligible
-    var targetId: string | undefined;
-    if (
-      hoverPrompt &&
-      // !prompts[hoverPrompt].isSaved &&
-      visiblePromptIDs.has(hoverPrompt)
-    ) {
-      targetId = hoverPrompt;
-    }
-    if (editPrompt) {
-      targetId = editPrompt;
-    }
-    const drawnId = promptIdToDrawnPromptId.get(targetId ?? "");
-    if (drawnId) {
-      const els = document.getElementsByClassName(
-        classNameForPromptID(drawnId),
-      );
-      for (const el of els) {
-        el.setAttribute("style", `background-color:${HOVER_COLOR};`);
+    hoverPrompts?.forEach((hoverPrompt) => {
+      var targetId: string | undefined;
+      if (
+        hoverPrompt &&
+        // !prompts[hoverPrompt].isSaved &&
+        visiblePromptIDs.has(hoverPrompt)
+      ) {
+        targetId = hoverPrompt;
       }
-    }
+      if (editPrompt) {
+        targetId = editPrompt;
+      }
+      const drawnId = promptIdToDrawnPromptId.get(targetId ?? "");
+      if (drawnId) {
+        const els = document.getElementsByClassName(
+          classNameForPromptID(drawnId),
+        );
+        for (const el of els) {
+          el.setAttribute("style", `background-color:${HOVER_COLOR};`);
+        }
+      }
+    });
   }, [
-    hoverPrompt,
+    hoverPrompts,
     editPrompt,
     prompts,
     visiblePromptIDs,

--- a/src/components/prompt/BulkPromptBox.tsx
+++ b/src/components/prompt/BulkPromptBox.tsx
@@ -24,7 +24,7 @@ export interface BulkPromptBoxProps {
   addToSaves?: (id: PromptId) => any;
   clearSaves?: () => any;
   saves?: Set<PromptId>;
-  setHoverPrompt?: (id: PromptId | undefined) => any;
+  setHoverPrompts?: (ids: PromptId[] | undefined) => any;
   setEditPrompt?: (id: PromptId | undefined) => any;
   setTops?: (id: PromptId, top: number) => any;
 }
@@ -82,7 +82,7 @@ export default function BulkPromptBox({
   clearSaves,
   updatePromptBack,
   updatePromptFront,
-  setHoverPrompt,
+  setHoverPrompts,
   setEditPrompt,
   setTops,
 }: BulkPromptBoxProps) {
@@ -162,7 +162,7 @@ export default function BulkPromptBox({
           updatePromptFront={(newPrompt: string) =>
             updatePromptFront(id, newPrompt)
           }
-          onMouseEnter={() => (setHoverPrompt ? setHoverPrompt(id) : null)}
+          onMouseEnter={() => (setHoverPrompts ? setHoverPrompts([id]) : null)}
           onEditStart={() => (setEditPrompt ? setEditPrompt(id) : null)}
           onEditEnd={() => (setEditPrompt ? setEditPrompt(undefined) : null)}
           ref={(el) => {
@@ -209,14 +209,14 @@ export default function BulkPromptBox({
       `}
       onMouseEnter={() => {
         setIsBulkPromptHovered(true);
-        if (setHoverPrompt) setHoverPrompt(ids[0]);
+        if (setHoverPrompts) setHoverPrompts(ids);
       }}
       onMouseLeave={() => {
         setIsBulkPromptHovered(false);
         if (!isFocused && clearSaves) {
           clearSaves();
         }
-        if (setHoverPrompt) setHoverPrompt(undefined);
+        if (setHoverPrompts) setHoverPrompts(undefined);
       }}
     >
       <>
@@ -233,7 +233,7 @@ export default function BulkPromptBox({
           setIsButtonHovered(true);
           setIsOpen(true);
           determineLayout();
-          if (setHoverPrompt) setHoverPrompt(ids[0]);
+          if (setHoverPrompts) setHoverPrompts(ids);
         }}
         onMouseLeave={() => {
           setIsButtonHovered(false);

--- a/src/components/prompt/PromptLayoutManager.tsx
+++ b/src/components/prompt/PromptLayoutManager.tsx
@@ -103,7 +103,7 @@ export function PromptLayoutManager({
     }
   }, [bulkSaves, setBulkSaves]);
 
-  const [currHoverPrompt, setHoverPrompt] = useState<PromptId>();
+  const [currHoverPrompts, setHoverPrompts] = useState<PromptId[]>();
   const [currEditPrompt, setEditPrompt] = useState<PromptId>();
   const [currAnchorHover, setCurrAnchorHover] = useState<PromptId>();
   // We have to let the shadow container mount and render for sizing
@@ -264,8 +264,8 @@ export function PromptLayoutManager({
                     dispatch(updatePromptBack([id, newPrompt]))
                   }
                   clearNew={clearNewPrompt}
-                  onMouseEnter={() => setHoverPrompt(id)}
-                  onMouseLeave={() => setHoverPrompt(undefined)}
+                  onMouseEnter={() => setHoverPrompts([id])}
+                  onMouseLeave={() => setHoverPrompts(undefined)}
                   onEditStart={() => setEditPrompt(id)}
                   onEditEnd={() => setEditPrompt(undefined)}
                 />
@@ -281,8 +281,8 @@ export function PromptLayoutManager({
                   pointerEvents: "none",
                   // Pop-up active bulk
                   zIndex:
-                    ids.indexOf(currHoverPrompt ?? "") !== -1 ||
-                    ids.indexOf(currEditPrompt ?? "") !== -1
+                    ids.indexOf(currHoverPrompts ? currHoverPrompts[0] : "") !==
+                      -1 || ids.indexOf(currEditPrompt ?? "") !== -1
                       ? zIndices.displayOverContent + 1
                       : zIndices.displayOverContent,
                 }}
@@ -309,7 +309,9 @@ export function PromptLayoutManager({
                   updatePromptBack={(id, newPrompt) =>
                     dispatch(updatePromptBack([id, newPrompt]))
                   }
-                  setHoverPrompt={(id) => setHoverPrompt(id)}
+                  setHoverPrompts={(ids: PromptId[] | undefined) =>
+                    setHoverPrompts(ids)
+                  }
                   setEditPrompt={(id) => setEditPrompt(id)}
                   setTops={(id, top) => {
                     bulkPromptLocations.current[id] = top;
@@ -326,7 +328,7 @@ export function PromptLayoutManager({
           [visiblePromptIDs],
         )}
         promptLocations={promptLocations}
-        hoverPrompt={currHoverPrompt}
+        hoverPrompts={currHoverPrompts}
         editPrompt={currEditPrompt}
         setHoverPrompt={setCurrAnchorHover}
       />


### PR DESCRIPTION
Adds a bulk hover by refactoring the hover state into an array. Two edge cases remain for hovering:

- We split a bulk prompt with shared anchors and then highlight its children (what happens when we highlight the anchor then?)
- We are in a bulk prompt hover, start editing, and then hover off. The edit anchor highlight should be preserved but


https://user-images.githubusercontent.com/5598697/191558788-8c7d52b7-e187-42ed-9e76-93bc66c37ec6.mov

