### PR TITLE
Handle Attachment Images

### DIFF
--- a/src/app/authSlice.ts
+++ b/src/app/authSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import {
+  AttachmentID,
   Event,
   EventID,
   EventType,
@@ -14,6 +15,7 @@ import {
 } from "@withorbit/core";
 import { getSiteName } from "../util/getSiteName";
 import { normalizeURL } from "../util/normalizeURL";
+import { getOrbitPromptProps } from "./inlineReviewModuleSlice";
 import { Prompt, PromptID, PromptSelectorType } from "./promptSlice";
 
 type OrbitSyncState = { queue: Event[] } & (
@@ -177,18 +179,19 @@ function getOrbitSelectors(prompt: Prompt): TaskProvenanceSelector[] {
 }
 
 function getOrbitSpec(prompt: Prompt): TaskSpec {
+  const promptProps = getOrbitPromptProps(prompt);
   return {
     type: TaskSpecType.Memory,
     content: {
       type: TaskContentType.QA,
       // TODO: handle attachments
       body: {
-        text: prompt.content.front,
+        text: promptProps.question,
         attachments: [],
       },
       answer: {
-        text: prompt.content.back,
-        attachments: [],
+        text: promptProps.answer,
+        attachments: promptProps["answer-attachments"] as AttachmentID[],
       },
     },
   };

--- a/src/app/inlineReviewModuleSlice.ts
+++ b/src/app/inlineReviewModuleSlice.ts
@@ -170,14 +170,13 @@ function populateReviewArea(
   for (const [id, prompt] of reviewAreaPromptIDs) {
     usedPromptIDs.add(id);
     const promptElement = document.createElement("orbit-prompt");
-    const props = getOrbitPromptProps(prompt);
+    const props = getOrbitPromptProps(prompt, true);
     promptElement.setAttribute("question", props.question);
     promptElement.setAttribute("answer", props.answer);
-    if (props["answer-attachments"].length) {
-      promptElement.setAttribute(
-        "answer-attachments",
-        props["answer-attachments"][0],
-      );
+    const answerURL = getAbsoluteAttachmentURL(props.answer);
+    // only supply the attribute if there's an actual value
+    if (answerURL) {
+      promptElement.setAttribute("answer-attachments", answerURL);
     }
     promptElement.id = id;
     reviewAreaElement.appendChild(promptElement);
@@ -211,10 +210,14 @@ function rangeCompareNode(range: Range, node: Node) {
 }
 
 // HACK: The embedded iframe (which uses the "real" Orbit bits) can't access local URLs. So we convert relative URLs of these images back to absolute paths on the original publication servers.
-function getAttachmentURL(text: string): string | null {
+function getAttachmentURL(
+  text: string,
+  forEmbeddedView: boolean,
+): string | null {
   const imageMatch = text.match(/<img src="(.+?)".+$/);
 
   if (imageMatch) {
+    if (!forEmbeddedView) return imageMatch[1];
     if (text.indexOf('<img src="data:') >= 0) return text;
     const resolved = new URL(imageMatch[1], document.baseURI).pathname;
     const inDomainSubpath = resolved.split("/").slice(2).join("/");
@@ -225,6 +228,7 @@ function getAttachmentURL(text: string): string | null {
     } else if (resolved.startsWith("/sh/br")) {
       return `https://bounded-regret.ghost.io/${inDomainSubpath}`;
     } else {
+      // absolute URLs to arbitrary images with: return imageMatch[1];
       throw new Error("Unsupported image URL");
     }
   } else {
@@ -232,24 +236,24 @@ function getAttachmentURL(text: string): string | null {
   }
 }
 
-export function getOrbitPromptProps({ content: { front, back } }: Prompt): {
+export function getOrbitPromptProps(
+  { content: { front, back } }: Prompt,
+  forEmbeddedView = false,
+): {
   question: string;
   answer: string;
-  "answer-attachments": string[];
+  "answer-attachments"?: string[] | null;
 } {
-  const attachmentURL = getAttachmentURL(back);
+  let attachmentURL = getAttachmentURL(back, forEmbeddedView);
 
   let answer = back;
-  let attachments: string[] = [];
-  if (attachmentURL) {
+  let attachments: string[] | null = null;
+
+  if (attachmentURL?.length) {
     answer = "";
     attachments = [attachmentURL];
-    // attachments = attachmentURL
-    //   ? [attachmentURL]
-    //   : backAttachments?.length
-    //   ? backAttachments
-    //   : [];
   }
+
   return {
     question: front,
     answer,

--- a/src/app/orbitSync.ts
+++ b/src/app/orbitSync.ts
@@ -1,7 +1,6 @@
 import OrbitAPIClient from "@withorbit/api-client";
 import {
   AttachmentID,
-  AttachmentIngestEvent,
   AttachmentMIMEType,
   encodeUUIDBytesToWebSafeBase64ID,
   EntityType,
@@ -18,28 +17,6 @@ import { APISyncAdapter, syncOrbitStore } from "@withorbit/sync";
 import { apiConfig } from "../config";
 import { normalizeURL } from "../util/normalizeURL";
 import { PromptID } from "./promptSlice";
-
-import { v5 as uuidV5 } from "uuid";
-
-const generateAttachmentIDForURL = (url: string): AttachmentID => {
-  const bytes = new Uint8Array(16);
-  uuidV5(url, uuidV5.URL, bytes);
-  return encodeUUIDBytesToWebSafeBase64ID(bytes) as AttachmentID;
-};
-
-const storeAttachment = async (
-  store: OrbitStoreWeb,
-  attachmentURL: string,
-  id: AttachmentID,
-  type: AttachmentMIMEType,
-) => {
-  const imgArrayBuffer = await fetch(attachmentURL).then((o) =>
-    o.arrayBuffer(),
-  );
-
-  const contents = new Uint8Array(imgArrayBuffer);
-  await store.attachmentStore.storeAttachment(contents, id, type);
-};
 
 const getAttachmentURLFromID = async (
   store: OrbitStoreWeb,
@@ -91,155 +68,13 @@ export class OrbitSyncManager {
         if (task.provenance?.identifier === matchingURL) {
           output[task.id] = task;
         }
-
-        // only handle 1 attachment for now
-        if (
-          "answer" in task.spec.content &&
-          task.spec.content.answer.attachments.length
-        ) {
-          const attachmentID = task.spec.content.answer.attachments[0];
-          task.spec.content.answer.text = `<img src="${await getAttachmentURLFromID(
-            this.store,
-            attachmentID,
-          )}" />`;
-        }
-
-        if (task.spec.content.body.attachments.length) {
-          const attachmentID = task.spec.content.body.attachments[0];
-          task.spec.content.body.text = `<img src="${await getAttachmentURLFromID(
-            this.store,
-            attachmentID,
-          )}" />`;
-        }
       }
     } while (tasks.length > 0);
     return output;
   }
+
   async storeAndSync(events: Event[]) {
-    // TODO: should the attachment events be generated before this? Or, can we just use ingestAttachmentFromURLs?
-
-    await this.store.database.putEvents(
-      events.filter((o) => o.type !== EventType.TaskIngest),
-    );
-
-    // keep attachment ids so we can use them when storing attachments
-    // Event[] stores attachments as URLs, which we convert here
-    const eventIDToAttachmentIDMap: {
-      [k: string]: {
-        answerAttachments?: AttachmentID[];
-        questionAttachments?: AttachmentID[];
-      };
-    } = {};
-
-    await this.store.database.putEvents(
-      events
-        .filter((o) => o.type === EventType.TaskIngest)
-        .map((o) => {
-          let ret = { ...o } as TaskIngestEvent;
-          if ("answer" in ret.spec.content) {
-            const answerAttachments = ret.spec.content.answer.attachments.map(
-              (attatchmentURL) => generateAttachmentIDForURL(attatchmentURL),
-            );
-
-            eventIDToAttachmentIDMap[ret.id] = { answerAttachments };
-
-            ret = {
-              ...ret,
-              spec: {
-                ...ret.spec,
-                content: {
-                  ...ret.spec.content,
-                  answer: {
-                    ...ret.spec.content.answer,
-                    attachments: answerAttachments,
-                  },
-                },
-              },
-            };
-          }
-
-          if (ret.spec.content.body.attachments.length) {
-            const questionAttachments = ret.spec.content.body.attachments.map(
-              (attatchmentURL) => generateAttachmentIDForURL(attatchmentURL),
-            );
-            eventIDToAttachmentIDMap[ret.id] = { questionAttachments };
-            ret = {
-              ...ret,
-              spec: {
-                ...ret.spec,
-                content: {
-                  ...ret.spec.content,
-                  body: {
-                    ...ret.spec.content.body,
-                    attachments: questionAttachments,
-                  },
-                },
-              },
-            };
-          }
-
-          return ret;
-        }),
-    );
-
-    // filter for attachments, convert attachment url to attachmentId, convert attachment data and store
-    // track AttachmentIngestEvents for later
-    const attachmentIngestEvents = [];
-    for (const eventWithAttachment of (events as TaskIngestEvent[]).filter(
-      (o) =>
-        o.type === EventType.TaskIngest &&
-        (("answer" in o.spec.content &&
-          o.spec.content.answer.attachments.length) ||
-          o.spec.content.body.attachments.length),
-    )) {
-      if ("answer" in eventWithAttachment.spec.content) {
-        const { answerAttachments = [] } =
-          eventIDToAttachmentIDMap[eventWithAttachment.id];
-        let arrIdx = 0;
-
-        for (const attachmentUrl of eventWithAttachment.spec.content.answer
-          .attachments) {
-          const id = answerAttachments[arrIdx];
-          const mimeType = getAttachmentMIMETypeForFilename(attachmentUrl);
-
-          if (id && mimeType) {
-            await storeAttachment(this.store, attachmentUrl, id, mimeType);
-            const newEvent: AttachmentIngestEvent = {
-              id: generateUniqueID(),
-              type: EventType.AttachmentIngest,
-              entityID: id,
-              timestampMillis: Date.now(),
-              mimeType,
-            };
-            attachmentIngestEvents.push(newEvent);
-          }
-          arrIdx++;
-        }
-      }
-
-      const { questionAttachments = [] } =
-        eventIDToAttachmentIDMap[eventWithAttachment.id];
-      let arrIdx = 0;
-      for (const attachmentUrl of eventWithAttachment.spec.content.body
-        .attachments) {
-        const id = questionAttachments[arrIdx];
-        const mimeType = getAttachmentMIMETypeForFilename(attachmentUrl);
-        if (id && mimeType) {
-          await storeAttachment(this.store, attachmentUrl, id, mimeType);
-          const newEvent: AttachmentIngestEvent = {
-            id: generateUniqueID(),
-            type: EventType.AttachmentIngest,
-            entityID: id,
-            timestampMillis: Date.now(),
-            mimeType,
-          };
-          attachmentIngestEvents.push(newEvent);
-        }
-        arrIdx++;
-      }
-    }
-
-    await this.store.database.putEvents(attachmentIngestEvents);
+    await this.store.database.putEvents(events);
     await this.sync();
   }
 

--- a/src/app/orbitSync.ts
+++ b/src/app/orbitSync.ts
@@ -1,13 +1,54 @@
 import OrbitAPIClient from "@withorbit/api-client";
-import { EntityType, Event, Task, TaskID } from "@withorbit/core";
+import {
+  AttachmentID,
+  AttachmentIngestEvent,
+  AttachmentMIMEType,
+  encodeUUIDBytesToWebSafeBase64ID,
+  EntityType,
+  Event,
+  EventType,
+  generateUniqueID,
+  getAttachmentMIMETypeForFilename,
+  Task,
+  TaskID,
+  TaskIngestEvent,
+} from "@withorbit/core";
 import OrbitStoreWeb from "@withorbit/store-web";
 import { APISyncAdapter, syncOrbitStore } from "@withorbit/sync";
 import { apiConfig } from "../config";
 import { normalizeURL } from "../util/normalizeURL";
 import { PromptID } from "./promptSlice";
 
-// NOTE: Explicitly ignoring race conditions throughout this file. It's a prototype!
+import { v5 as uuidV5 } from "uuid";
 
+const generateAttachmentIDForURL = (url: string): AttachmentID => {
+  const bytes = new Uint8Array(16);
+  uuidV5(url, uuidV5.URL, bytes);
+  return encodeUUIDBytesToWebSafeBase64ID(bytes) as AttachmentID;
+};
+
+const storeAttachment = async (
+  store: OrbitStoreWeb,
+  attachmentURL: string,
+  id: AttachmentID,
+  type: AttachmentMIMEType,
+) => {
+  const imgArrayBuffer = await fetch(attachmentURL).then((o) =>
+    o.arrayBuffer(),
+  );
+
+  const contents = new Uint8Array(imgArrayBuffer);
+  await store.attachmentStore.storeAttachment(contents, id, type);
+};
+
+const getAttachmentURLFromID = async (
+  store: OrbitStoreWeb,
+  id: AttachmentID,
+) => {
+  return await store.attachmentStore.getURLForStoredAttachment(id);
+};
+
+// NOTE: Explicitly ignoring race conditions throughout this file. It's a prototype!
 export class OrbitSyncManager {
   private store: OrbitStoreWeb;
   private apiClient: OrbitAPIClient;
@@ -50,13 +91,155 @@ export class OrbitSyncManager {
         if (task.provenance?.identifier === matchingURL) {
           output[task.id] = task;
         }
+
+        // only handle 1 attachment for now
+        if (
+          "answer" in task.spec.content &&
+          task.spec.content.answer.attachments.length
+        ) {
+          const attachmentID = task.spec.content.answer.attachments[0];
+          task.spec.content.answer.text = `<img src="${await getAttachmentURLFromID(
+            this.store,
+            attachmentID,
+          )}" />`;
+        }
+
+        if (task.spec.content.body.attachments.length) {
+          const attachmentID = task.spec.content.body.attachments[0];
+          task.spec.content.body.text = `<img src="${await getAttachmentURLFromID(
+            this.store,
+            attachmentID,
+          )}" />`;
+        }
       }
     } while (tasks.length > 0);
     return output;
   }
-
   async storeAndSync(events: Event[]) {
-    await this.store.database.putEvents(events);
+    // TODO: should the attachment events be generated before this? Or, can we just use ingestAttachmentFromURLs?
+
+    await this.store.database.putEvents(
+      events.filter((o) => o.type !== EventType.TaskIngest),
+    );
+
+    // keep attachment ids so we can use them when storing attachments
+    // Event[] stores attachments as URLs, which we convert here
+    const eventIDToAttachmentIDMap: {
+      [k: string]: {
+        answerAttachments?: AttachmentID[];
+        questionAttachments?: AttachmentID[];
+      };
+    } = {};
+
+    await this.store.database.putEvents(
+      events
+        .filter((o) => o.type === EventType.TaskIngest)
+        .map((o) => {
+          let ret = { ...o } as TaskIngestEvent;
+          if ("answer" in ret.spec.content) {
+            const answerAttachments = ret.spec.content.answer.attachments.map(
+              (attatchmentURL) => generateAttachmentIDForURL(attatchmentURL),
+            );
+
+            eventIDToAttachmentIDMap[ret.id] = { answerAttachments };
+
+            ret = {
+              ...ret,
+              spec: {
+                ...ret.spec,
+                content: {
+                  ...ret.spec.content,
+                  answer: {
+                    ...ret.spec.content.answer,
+                    attachments: answerAttachments,
+                  },
+                },
+              },
+            };
+          }
+
+          if (ret.spec.content.body.attachments.length) {
+            const questionAttachments = ret.spec.content.body.attachments.map(
+              (attatchmentURL) => generateAttachmentIDForURL(attatchmentURL),
+            );
+            eventIDToAttachmentIDMap[ret.id] = { questionAttachments };
+            ret = {
+              ...ret,
+              spec: {
+                ...ret.spec,
+                content: {
+                  ...ret.spec.content,
+                  body: {
+                    ...ret.spec.content.body,
+                    attachments: questionAttachments,
+                  },
+                },
+              },
+            };
+          }
+
+          return ret;
+        }),
+    );
+
+    // filter for attachments, convert attachment url to attachmentId, convert attachment data and store
+    // track AttachmentIngestEvents for later
+    const attachmentIngestEvents = [];
+    for (const eventWithAttachment of (events as TaskIngestEvent[]).filter(
+      (o) =>
+        o.type === EventType.TaskIngest &&
+        (("answer" in o.spec.content &&
+          o.spec.content.answer.attachments.length) ||
+          o.spec.content.body.attachments.length),
+    )) {
+      if ("answer" in eventWithAttachment.spec.content) {
+        const { answerAttachments = [] } =
+          eventIDToAttachmentIDMap[eventWithAttachment.id];
+        let arrIdx = 0;
+
+        for (const attachmentUrl of eventWithAttachment.spec.content.answer
+          .attachments) {
+          const id = answerAttachments[arrIdx];
+          const mimeType = getAttachmentMIMETypeForFilename(attachmentUrl);
+
+          if (id && mimeType) {
+            await storeAttachment(this.store, attachmentUrl, id, mimeType);
+            const newEvent: AttachmentIngestEvent = {
+              id: generateUniqueID(),
+              type: EventType.AttachmentIngest,
+              entityID: id,
+              timestampMillis: Date.now(),
+              mimeType,
+            };
+            attachmentIngestEvents.push(newEvent);
+          }
+          arrIdx++;
+        }
+      }
+
+      const { questionAttachments = [] } =
+        eventIDToAttachmentIDMap[eventWithAttachment.id];
+      let arrIdx = 0;
+      for (const attachmentUrl of eventWithAttachment.spec.content.body
+        .attachments) {
+        const id = questionAttachments[arrIdx];
+        const mimeType = getAttachmentMIMETypeForFilename(attachmentUrl);
+        if (id && mimeType) {
+          await storeAttachment(this.store, attachmentUrl, id, mimeType);
+          const newEvent: AttachmentIngestEvent = {
+            id: generateUniqueID(),
+            type: EventType.AttachmentIngest,
+            entityID: id,
+            timestampMillis: Date.now(),
+            mimeType,
+          };
+          attachmentIngestEvents.push(newEvent);
+        }
+        arrIdx++;
+      }
+    }
+
+    await this.store.database.putEvents(attachmentIngestEvents);
     await this.sync();
   }
 

--- a/src/app/promptSlice.ts
+++ b/src/app/promptSlice.ts
@@ -142,18 +142,24 @@ const promptSlice = createSlice({
           console.warn("Ignoring non-QA task", task);
           continue;
         }
-        // TODO: attachments
+
+        const prompt = state[id];
+
         const promptContent = {
           front: content.body.text,
-          back: content.answer.text,
+          // prioritize hard-coded image sources
+          // this could change if we allow for changing image sources or annotating them
+          back: prompt?.content.back.match(/<img src="(.+?)".+$/)
+            ? prompt?.content.back
+            : content.answer.text,
         };
+
         const isSaved = !task.isDeleted;
         const isDue =
           isSaved &&
           task.componentStates[mainTaskComponentID].dueTimestampMillis <=
             getReviewQueueFuzzyDueTimestampThreshold(Date.now());
 
-        const prompt = state[id];
         if (prompt) {
           prompt.isSaved = isSaved;
           prompt.isDue = isDue;

--- a/src/app/promptSlice.ts
+++ b/src/app/promptSlice.ts
@@ -18,6 +18,7 @@ export interface Prompt {
   content: {
     front: string;
     back: string;
+    backAttachments?: string[];
   };
   selectors: PromptSelector[];
 
@@ -148,7 +149,6 @@ const promptSlice = createSlice({
         const promptContent = {
           front: content.body.text,
           // prioritize hard-coded image sources
-          // this could change if we allow for changing image sources or annotating them
           back: prompt?.content.back.match(/<img src="(.+?)".+$/)
             ? prompt?.content.back
             : content.answer.text,

--- a/src/components/ModalReview.tsx
+++ b/src/components/ModalReview.tsx
@@ -92,7 +92,7 @@ export function ModalReview(props: ModalReviewProps) {
         >
           {queuedPromptIDs.map((id) => (
             <orbit-prompt
-              {...getOrbitPromptProps(prompts[id])}
+              {...getOrbitPromptProps(prompts[id], true)}
               id={id}
               key={id}
             ></orbit-prompt>

--- a/src/util/resolvePromptLocations.ts
+++ b/src/util/resolvePromptLocations.ts
@@ -21,15 +21,11 @@ export async function resolvePromptLocations(prompts: {
             },
           ];
         } catch (e) {
-          throw new Error(
-            `Prompt resolution error: ${e}\n${JSON.stringify(
-              prompt,
-              null,
-              "\t",
-            )}`,
-          );
+          return [id, false];
         }
       }),
+    ).then((promptEntries) =>
+      promptEntries.filter(([, promptLocation]) => promptLocation),
     ),
   );
 }


### PR DESCRIPTION
- feed absolute attachment URLs into embedded view, to be picked up by `embeddedNetworkQueue`
  - NOTE: it looks like you need to complete the review to get the sync to go through (e.g skip/mark everything)
 
I tried to alleviate the above by manually sending ingest task events and storing attachments BEFORE the review opens (see [this commit](https://github.com/andymatuschak/orbit-summer-2022-demo/commit/afaa5dcaa3d78c69ac5d2ccaced72c57ec703802), but that led to other issues. It did help to understand the sync and event setup, though.