### PR TITLE
Add option to specify latex tags style

### DIFF
--- a/backend/bin/exportAnkiDeck.js
+++ b/backend/bin/exportAnkiDeck.js
@@ -3,13 +3,22 @@ import fs from "node:fs";
 
 const inputPath = process.argv[2];
 const outputPath = process.argv[3];
+let latexTagsStyle = process.argv[4] || "anki";
 if (!inputPath || !outputPath) {
-  console.error("Usage: yarn exportAnkiDeck <input.json> <output.apkg>");
+  console.error("Usage: yarn exportAnkiDeck <input.json> <output.apkg> [anki|mnemosyne]");
   process.exit(1);
 }
 
+if (process.argv.length > 4 && ["anki", "mnemosyne"].indexOf(latexTagsStyle) < 0) {
+  console.warn(
+    `I support exporting "anki"-style LaTeX delimeters, \\(...\\), and "mnemosyne"-style LaTeX delimeters, <$>...</$>.`
+    + ` You requested "${process.argv[4]}"-style delimeters, which I don't know. I'm defaulting to \"anki\".`
+  );
+  latexTagsStyle = "anki";
+}
+
 const input = JSON.parse(fs.readFileSync(inputPath, "utf8"));
-const { data } = await prepareAnkiDeck(input);
+const { data } = await prepareAnkiDeck(input, latexTagsStyle);
 
 fs.writeFileSync(outputPath, data);
 console.log("Wrote", outputPath);


### PR DESCRIPTION
First screenshot is what the import looks like immediately after import. Window on the left is a new database with the import. Window on the right is an existing database with hand-crafted cards.

![image](https://github.com/andymatuschak/orbit-summer-2022-demo/assets/1719584/0e3432e5-8d40-4205-b065-01a5e5097425)

The formatting changes if you change the card type. Mnemosyne imports Anki cards as their own special card type.

![image](https://github.com/andymatuschak/orbit-summer-2022-demo/assets/1719584/233e34e2-c2c6-4ead-9e56-f1ed94fdae89)

Changing the card type to Mnemosyne's default front/back card type changes the format to look like this:

![image](https://github.com/andymatuschak/orbit-summer-2022-demo/assets/1719584/ea24ca23-fa85-4b01-9da2-7e4471faaa81)
